### PR TITLE
Add transmission of lot_id from move to procurement and delete lot_id on copy.

### DIFF
--- a/sale_order_lot_selection/model/__init__.py
+++ b/sale_order_lot_selection/model/__init__.py
@@ -21,3 +21,4 @@
 
 from . import sale
 from . import procurement
+from . import stock

--- a/sale_order_lot_selection/model/sale.py
+++ b/sale_order_lot_selection/model/sale.py
@@ -99,3 +99,10 @@ class sale_order(models.Model):
                         raise Warning(_('Can\'t reserve products for lot %s') %
                                       line.lot_id.name)
         return True
+
+    def copy_data(self, cr, uid, id, default=None, context=None):
+        if default is None:
+            default = {}
+        default['lot_id'] = False
+        return super(SaleOrderLine, self).copy_data(
+            cr, uid, id, default, context=context)

--- a/sale_order_lot_selection/model/stock.py
+++ b/sale_order_lot_selection/model/stock.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#   Module for Odoo
+#   Copyright (C) 2015 Akretion (http://www.akretion.com).
+#   @author Valentin CHEMIERE <valentin.chemiere@akretion.com>
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.ArithmeticError#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.ArithmeticError#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see
+#   <http://www.gnu.org/licenses/>.ArithmeticError#
+###############################################################################
+
+from openerp import fields, api, models
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    @api.model
+    def _prepare_procurement_from_move(self, move):
+        vals = super(StockMove, self)._prepare_procurement_from_move(move)
+        vals['lot_id'] = move.restrict_lot_id.id
+        return vals


### PR DESCRIPTION
Add transmission of lot_id from move to procurement and delete lot_id on copy.
As suggered here https://github.com/OCA/sale-workflow/pull/177